### PR TITLE
Remove "try" function from s3 expiration settings

### DIFF
--- a/modules/secure-s3-bucket/main.tf
+++ b/modules/secure-s3-bucket/main.tf
@@ -140,9 +140,9 @@ resource "aws_s3_bucket" "secure_s3_bucket" {
       }
     }
     expiration {
-      date                         = try(var.lifecycle_rule_expiration.date, null)
-      days                         = try(var.lifecycle_rule_expiration.days, null)
-      expired_object_delete_marker = try(var.lifecycle_rule_expiration.expired_object_delete_marker, null)
+      date                         = var.lifecycle_rule_expiration.date
+      days                         = var.lifecycle_rule_expiration.days
+      expired_object_delete_marker = var.lifecycle_rule_expiration.expired_object_delete_marker
     }
   }
 


### PR DESCRIPTION
Follow-up to https://github.com/centriascolocation/terraform-aws-security/pull/17:
After closer inspection I noticed that the "try" function here will do
more harm than good. As the default values are already set to null, all
the try function would do is replace invalid settings with null,
obscuring any issues introduced by the user in the progress.